### PR TITLE
Wrap gitleaks anywhere

### DIFF
--- a/github-repo-searcher.py
+++ b/github-repo-searcher.py
@@ -41,7 +41,7 @@ print("[+] Running git-leaks check on each repo found...")
 
 for each in response4:
     print("\033[33m[+] Scanning repo: %s\033[0m" % each)
-    cmd = "./gitleaks -v --repo=%s"%each
+    cmd = "./gitleaks -v --repo-url=%s"%each
     os.system(cmd)
     print("-----------------------------------------------------")
     print("-----------------------------------------------------")

--- a/github-repo-searcher.py
+++ b/github-repo-searcher.py
@@ -41,7 +41,7 @@ print("[+] Running git-leaks check on each repo found...")
 
 for each in response4:
     print("\033[33m[+] Scanning repo: %s\033[0m" % each)
-    cmd = "./gitleaks -v --repo-url=%s"%each
+    cmd = "gitleaks -v --repo-url=%s"%each
     os.system(cmd)
     print("-----------------------------------------------------")
     print("-----------------------------------------------------")


### PR DESCRIPTION
Removes requirement that `gitleaks` is in the current directory, so it can be installed anywhere and used with this script as long as it's in your `PATH`. If you'd rather keep it the way it is, that makes sense, too. 😄 

(This branch/PR is also based on cedowens/gitleaks-wrapper#1 so it'll work with the latest `gitleaks`)